### PR TITLE
Removed libgcc run dependency as not required.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,12 +10,8 @@ source:
     md5: 241a5825d00a36055fcc71874d97cf7b
 
 build:
-    number: 0
+    number: 1
     skip: True  # [win]
-
-requirements:
-    run:
-        - libgcc
 
 test:
     commands:


### PR DESCRIPTION
This change is included as part of a separate PR (#2) for which the build is currently failing. Submitting as separate request until issue with make check can be resolved.
